### PR TITLE
Dan - SwipingFragment, MatchesFragment, Notifications fixes

### DIFF
--- a/app/src/main/java/com/greenfox/gitinder/activity/MainActivity.java
+++ b/app/src/main/java/com/greenfox/gitinder/activity/MainActivity.java
@@ -42,9 +42,6 @@ public class MainActivity extends AppCompatActivity implements MatchService.NewM
     SharedPreferences sharedPreferences;
 
     @Inject
-    NotificationService notificationService;
-
-    @Inject
     MatchService matchService;
 
     FloatingActionButton floatingActionButton;
@@ -56,13 +53,9 @@ public class MainActivity extends AppCompatActivity implements MatchService.NewM
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        Match match = MatchFactory.createNewMatch();
-        notificationService.createNotificationChannel(this);
-        notificationService.pushNewMatchNotification(match, this);
-
         toolbar = findViewById(R.id.main_toolbar);
-        floatingActionButtonText = findViewById(R.id.floating_action_button_text);
         floatingActionButton = findViewById(R.id.floating_action_button);
+        floatingActionButtonText = findViewById(R.id.floating_action_button_text);
 
         hideFloatingButtonWhenNoNewMatches();
         matchService.setNewMatchCountListener(this);

--- a/app/src/main/java/com/greenfox/gitinder/fragment/main/MatchesFragment.java
+++ b/app/src/main/java/com/greenfox/gitinder/fragment/main/MatchesFragment.java
@@ -10,9 +10,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 
-import com.greenfox.gitinder.BuildConfig;
 import com.greenfox.gitinder.Constants;
 import com.greenfox.gitinder.R;
 import com.greenfox.gitinder.adapter.MatchAdapter;
@@ -45,9 +43,6 @@ public class MatchesFragment extends BaseFragment {
 
     MatchAdapter matchAdapter;
 
-    public Button addMatchesButton;
-    Button clearMatchesButton;
-
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
@@ -58,20 +53,10 @@ public class MatchesFragment extends BaseFragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         RecyclerView recyclerView = view.findViewById(R.id.fragment_matches_recycler_view);
-        addMatchesButton = getView().findViewById(R.id.add_matches_button);
-        clearMatchesButton = getView().findViewById(R.id.clear_matches_button);
-
-        if(!BuildConfig.FLAVOR.equals("dev")){
-            addMatchesButton.setVisibility(View.GONE);
-            clearMatchesButton.setVisibility(View.GONE);
-        }
 
         matchAdapter = new MatchAdapter(getActivity().getApplicationContext(), matchService);
         recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
         recyclerView.setAdapter(matchAdapter);
-
-        addMatchesButton.setOnClickListener(v -> updateMatches());
-        clearMatchesButton.setOnClickListener(v -> matchService.clearMatches());
     }
 
     public void updateMatches(){

--- a/app/src/main/java/com/greenfox/gitinder/fragment/main/MatchesFragment.java
+++ b/app/src/main/java/com/greenfox/gitinder/fragment/main/MatchesFragment.java
@@ -19,6 +19,7 @@ import com.greenfox.gitinder.api.service.MatchService;
 import com.greenfox.gitinder.fragment.BaseFragment;
 import com.greenfox.gitinder.model.Match;
 import com.greenfox.gitinder.model.Matches;
+import com.greenfox.gitinder.service.NotificationService;
 
 import java.util.List;
 

--- a/app/src/main/java/com/greenfox/gitinder/fragment/main/SwipingFragment.java
+++ b/app/src/main/java/com/greenfox/gitinder/fragment/main/SwipingFragment.java
@@ -63,7 +63,7 @@ public class SwipingFragment extends BaseFragment implements CardStackListener {
         View view = inflater.inflate(R.layout.swiping_fragment, container, false);
         return view;
     }
-
+ 
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
@@ -89,19 +89,19 @@ public class SwipingFragment extends BaseFragment implements CardStackListener {
             extinctText.setText("");
         }
 
-        Call<SwipeResponse> call = gitinderAPI.swipe(
-                sharedPreferences.getString(Constants.GITINDER_TOKEN, ""),
-                sharedPreferences.getString(Constants.USERNAME, ""),
-                direction.toString().toLowerCase());
-
-        call.enqueue(new CustomCallback<SwipeResponse>() {
-            @Override
-            public void onResponse(Call<SwipeResponse> call, Response<SwipeResponse> response) {
-                if (!(response.body().getMatch() == null)){
-                    matchService.addMatch(response.body().getMatch());
-                }
-            }
-        });
+//        Call<SwipeResponse> call = gitinderAPI.swipe(
+//                sharedPreferences.getString(Constants.GITINDER_TOKEN, ""),
+//                sharedPreferences.getString(Constants.USERNAME, ""),
+//                direction.toString().toLowerCase());
+//
+//        call.enqueue(new CustomCallback<SwipeResponse>() {
+//            @Override
+//            public void onResponse(Call<SwipeResponse> call, Response<SwipeResponse> response) {
+//                if (!(response.body().getMatch() == null)){
+//                    matchService.addMatch(response.body().getMatch());
+//                }
+//            }
+//        });
         
         profileDirection(manager.getTopPosition(),direction);
     }
@@ -180,12 +180,15 @@ public class SwipingFragment extends BaseFragment implements CardStackListener {
 
     private void profileDirection(int position,Direction direction){
         Call<SwipeResponse> call = gitinderAPI.swipe(sharedPreferences.getString(Constants.GITINDER_TOKEN,"aaa"),
-                adapter.getProfiles().get(position).getUsername(),direction.toString());
+                adapter.getProfiles().get(position).getUsername(),direction.toString().toLowerCase());
 
         call.enqueue(new Callback<SwipeResponse>() {
             @Override
             public void onResponse(Call<SwipeResponse> call, Response<SwipeResponse> response) {
                 Log.d(TAG, "Profile direction added - SUCCESS");
+                if (!(response.body().getMatch() == null)){
+                    matchService.addMatch(response.body().getMatch());
+                }
             }
 
             @Override

--- a/app/src/main/java/com/greenfox/gitinder/fragment/main/SwipingFragment.java
+++ b/app/src/main/java/com/greenfox/gitinder/fragment/main/SwipingFragment.java
@@ -236,6 +236,7 @@ public class SwipingFragment extends BaseFragment implements CardStackListener {
 
     @Override
     public void reload() {
+        disableButtonsAndSwiping();
         if (adapter.getItemCount() == 0) {
             showProgressBar();
             loadProfiles();

--- a/app/src/main/java/com/greenfox/gitinder/fragment/main/SwipingFragment.java
+++ b/app/src/main/java/com/greenfox/gitinder/fragment/main/SwipingFragment.java
@@ -22,7 +22,10 @@ import com.greenfox.gitinder.api.model.SwipeResponse;
 import com.greenfox.gitinder.api.service.GitinderAPI;
 import com.greenfox.gitinder.api.service.MatchService;
 import com.greenfox.gitinder.fragment.BaseFragment;
+import com.greenfox.gitinder.model.Match;
 import com.greenfox.gitinder.model.Profile;
+import com.greenfox.gitinder.model.factory.MatchFactory;
+import com.greenfox.gitinder.service.NotificationService;
 import com.yuyakaido.android.cardstackview.CardStackLayoutManager;
 import com.yuyakaido.android.cardstackview.CardStackListener;
 import com.yuyakaido.android.cardstackview.CardStackView;
@@ -55,6 +58,9 @@ public class SwipingFragment extends BaseFragment implements CardStackListener {
 
     @Inject
     MatchService matchService;
+
+    @Inject
+    NotificationService notificationService;
 
     Button likeButton;
     Button nopeButton;
@@ -192,6 +198,8 @@ public class SwipingFragment extends BaseFragment implements CardStackListener {
                 Log.d(TAG, "Profile direction added - SUCCESS");
                 if (!(response.body().getMatch() == null)){
                     matchService.addMatch(response.body().getMatch());
+                    notificationService.createNotificationChannel(getActivity());
+                    notificationService.pushNewMatchNotification(response.body().getMatch(), getActivity());
                 }
             }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -35,13 +35,16 @@
         android:id="@+id/floating_action_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginLeft="8dp"
         android:layout_marginEnd="10dp"
         android:layout_marginRight="10dp"
         android:layout_marginBottom="10dp"
         android:clickable="true"
         app:fabCustomSize="65dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
     <android.support.design.widget.TabLayout
         android:id="@+id/tabs"

--- a/app/src/main/res/layout/matches_fragment.xml
+++ b/app/src/main/res/layout/matches_fragment.xml
@@ -6,26 +6,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <Button
-        android:id="@+id/add_matches_button"
-        android:layout_width="wrap_content"
-        android:layout_height="55dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginLeft="8dp"
-        android:layout_marginBottom="8dp"
-        android:text="@string/add_matches_button_text"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
-
-    <Button
-        android:id="@+id/clear_matches_button"
-        android:layout_width="0dp"
-        android:layout_height="55dp"
-        android:text="@string/clear_matches_button_text"
-        app:layout_constraintBottom_toTopOf="@+id/add_matches_button"
-        app:layout_constraintEnd_toEndOf="@+id/add_matches_button"
-        app:layout_constraintStart_toStartOf="@+id/add_matches_button" />
-
     <android.support.v7.widget.RecyclerView
         android:id="@+id/fragment_matches_recycler_view"
         android:layout_width="0dp"


### PR DESCRIPTION
**The LIKE and NOPE buttons were causing multiple swipes instead of a single one.** 
- Using a handler, I now set the buttons and the cards non-clickable until all the swiping logic is finished.

**Notification now not onCreate.**
- Got rid of the creation of a notification upon starting MainActivity and instead it will be created along with the match every 2 right swipes.

**ADD and CLEAR buttons in MatchesFragment**
- Removed them -> it's nicer for the demo and we will add the matches using the 2 right swipes.